### PR TITLE
Use reply_to instead of JMSReplyTo to work with broker

### DIFF
--- a/artemis.js
+++ b/artemis.js
@@ -116,7 +116,7 @@ Artemis.prototype._send_pending_requests = function () {
 }
 
 Artemis.prototype._send_request = function (request) {
-    request.application_properties.JMSReplyTo = this.address;
+    request.reply_to = this.address;
     this.sender.send(request);
     console.log('[' + this.connection.container_id + '] sent: ' + JSON.stringify(request));
 }


### PR DESCRIPTION
@grs With the updated Artemis, I had to change this to allow management operations to get replies